### PR TITLE
Update ConnectorUtils.java

### DIFF
--- a/android/src/main/java/com/example/wifi_configuration/manager/ConnectorUtils.java
+++ b/android/src/main/java/com/example/wifi_configuration/manager/ConnectorUtils.java
@@ -185,10 +185,6 @@ public final class ConnectorUtils {
         if (id == -1)
             return false;
 
-        if (!wifiManager.saveConfiguration()) {
-            WifiUtils.wifiLog("Couldn't save wifi config");
-            return false;
-        }
         // We have to retrieve the WifiConfiguration after save
         config = ConfigSecurities.getWifiConfiguration(wifiManager, config);
         if (config == null) {


### PR DESCRIPTION
WifiManager.saveConfiguration usage is removed from connectToWifi method

Save configuration method is deprecated since API level 26 (Ref. https://developer.android.com/reference/android/net/wifi/WifiManager#saveConfiguration()).